### PR TITLE
Dockerize Elixir Application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ elixir_todo_list-*.tar
 npm-debug.log
 /assets/node_modules/
 
+# Ignore docker related files.
+/_pgdata

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# https://elixirforum.com/t/elixir-phoenix-running-a-dev-setup-inside-docker/43269
+FROM elixir:latest
+
+RUN apt-get update && \
+    apt-get install -y curl && \
+    apt-get install -y postgresql-client && \
+    apt-get install -y inotify-tools
+
+# https://stackoverflow.com/a/57546198
+ENV NVM_DIR=/root/.nvm
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.4/install.sh | bash
+# https://stackoverflow.com/a/41792420
+ARG NODE_VERSION
+RUN . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION}
+RUN . "$NVM_DIR/nvm.sh" && nvm use v${NODE_VERSION}
+RUN . "$NVM_DIR/nvm.sh" && nvm alias default v${NODE_VERSION}
+ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
+
+
+RUN mix local.hex --force && \
+    mix archive.install hex phx_new --force && \
+    mix local.rebar --force
+
+ENV APP_HOME /app
+RUN mkdir $APP_HOME
+WORKDIR $APP_HOME

--- a/README.md
+++ b/README.md
@@ -1,18 +1,17 @@
 # ElixirTodoList
 
-To start your Phoenix server:
+## Requirements
 
-  * Run `mix setup` to install and setup dependencies
-  * Start Phoenix endpoint with `mix phx.server` or inside IEx with `iex -S mix phx.server`
+- Docker
+- Docker Compose
 
-Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.
+## Run the Application
 
-Ready to run in production? Please [check our deployment guides](https://hexdocs.pm/phoenix/deployment.html).
+- Run via Docker
 
-## Learn more
+```bash
+docker compose up -d
+```
 
-  * Official website: https://www.phoenixframework.org/
-  * Guides: https://hexdocs.pm/phoenix/overview.html
-  * Docs: https://hexdocs.pm/phoenix
-  * Forum: https://elixirforum.com/c/phoenix-forum
-  * Source: https://github.com/phoenixframework/phoenix
+- Note: There is no docker build optimized for production use
+DO NOT RUN IN PRODUCTION

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -2,10 +2,11 @@ import Config
 
 # Configure your database
 config :elixir_todo_list, ElixirTodoList.Repo,
-  username: "postgres",
-  password: "postgres",
-  hostname: "localhost",
-  database: "elixir_todo_list_dev",
+  username: System.get_env("PGUSER", "postgres"),
+  password: System.get_env("PGPASSWORD", "postgres"),
+  database: System.get_env("PGDATABASE", "elixir_todo_dev"),
+  hostname: System.get_env("PGHOST", "localhost"),
+  port: String.to_integer(System.get_env("PGPORT", "5432")),
   stacktrace: true,
   show_sensitive_data_on_connection_error: true,
   pool_size: 10
@@ -19,7 +20,7 @@ config :elixir_todo_list, ElixirTodoList.Repo,
 config :elixir_todo_list, ElixirTodoListWeb.Endpoint,
   # Binding to loopback ipv4 address prevents access from other machines.
   # Change to `ip: {0, 0, 0, 0}` to allow access from other machines.
-  http: [ip: {127, 0, 0, 1}, port: 4000],
+  http: [ip: {0, 0, 0, 0}, port: 4000],
   check_origin: false,
   code_reloader: true,
   debug_errors: true,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+version: "3"
+
+services:
+  phoenix:
+    build:
+      context: .
+      args:
+        NODE_VERSION: 18.16.1
+    volumes:
+      - .:/app
+    ports:
+      - "4000:4000"
+    environment:
+      PGUSER: postgres
+      PGPASSWORD: postgres
+      PGDATABASE: elixir_todo_dev
+      PGHOST: db
+      PGPORT: 5432
+    depends_on:
+      - db
+    command:
+      - "./entrypoint.sh"
+  db:
+    image: postgres:12.15-alpine
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      PGDATA: /var/lib/postgresql/data/pgdata
+    ports:
+      # https://www.mend.io/free-developer-tools/blog/docker-expose-port/
+      # Host Port: Container Port
+      - 5433:5432
+    volumes:
+      - ./_pgdata:/var/lib/postgresql/data

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -e
+
+# Ensure the app's dependencies are installed
+mix deps.get
+
+if [[ -f assets/package.json ]]; then
+  # Install the app's dependencies with npm
+  cd assets
+  npm install
+  cd ..
+fi
+
+# Wait until Postgres is ready
+while ! pg_isready -q -h $PGHOST -p $PGPORT -U $PGUSER
+do
+  echo "$(date) - waiting for database to start"
+  sleep 2
+done
+
+# Create, migrate, and seed database if it doesn't exist.
+if [[ -z `psql -Atqc "\\list $PGDATABASE"` ]]; then
+  echo "Database $PGDATABASE does not exist. Creating..."
+  createdb -E UTF8 $PGDATABASE -l en_US.UTF-8 -T template0
+  mix ecto.create
+  mix ecto.migrate
+  mix run priv/repo/seeds.exs
+  echo "Database $PGDATABASE created."
+fi
+
+mix phx.server


### PR DESCRIPTION
- Add ability to run the Phoenix application via Docker
- Container port 5432 is exposed to the local machine's 5433 port to ensure no conflicts in case a local postgres installation is present
- Application should be available at `localhost:4000` on the local machine once everything is built and running